### PR TITLE
Changed table key from topic -> question

### DIFF
--- a/web-app/src/app/questions/Table.tsx
+++ b/web-app/src/app/questions/Table.tsx
@@ -132,7 +132,7 @@ export function TableSort({ data }: TableSortProps) {
   };
 
   const rows = sortedData.map((row) => (
-    <tr key={row.topic}>
+    <tr key={row.question}>
       <td>{row.topic}</td>
       <td>{row.question}</td>
       <td


### PR DESCRIPTION
This fixes the previous issue of question duplication in the questions table. Will want to investigate using different values for the key, such as the question ID.