### PR TITLE
Question routing with question id instead of title

### DIFF
--- a/web-app/src/app/questions/Table.tsx
+++ b/web-app/src/app/questions/Table.tsx
@@ -43,6 +43,7 @@ const useStyles = createStyles((theme) => ({
 }));
 
 interface RowData {
+  id: string;
   topic: string;
   question: string;
   difficulty: string;
@@ -133,31 +134,30 @@ export function TableSort({ data }: TableSortProps) {
   };
 
  
-const rows = sortedData.map((row) => (
-  <tr key={row.question}>
-    <td>
-      <span>{row.topic}</span>
-    </td>
-    <td>
-      <Link href={`/questions/${encodeURIComponent(row.question)}`}>
-        {row.question}
-      </Link>
-    </td>
-    <td
-      style={{
-        color:
-          row.difficulty === "Beginner"
-            ? "#37b24d"
-            : row.difficulty === "Intermediate"
-            ? "#f59f00"
-            : "#f03e3e",
-      }}
-    >
-      {row.difficulty}
-    </td>
-  </tr>
-));
-
+  const rows = sortedData.map((row) => (
+    <tr key={row.question}>
+      <td>
+        <span>{row.topic}</span>
+      </td>
+      <td>
+        <Link href={`/questions/${row.id}`} passHref>
+          {row.question}
+        </Link>
+      </td>
+      <td
+        style={{
+          color:
+            row.difficulty === "Beginner"
+              ? "#37b24d"
+              : row.difficulty === "Intermediate"
+              ? "#f59f00"
+              : "#f03e3e",
+        }}
+      >
+        {row.difficulty}
+      </td>
+    </tr>
+  ));  
 
   return (
     <ScrollArea>

--- a/web-app/src/app/questions/[question]/404page.tsx
+++ b/web-app/src/app/questions/[question]/404page.tsx
@@ -1,0 +1,77 @@
+import {
+  createStyles,
+  Title,
+  Text,
+  Button,
+  Container,
+  Group,
+  rem,
+} from "@mantine/core";
+
+const useStyles = createStyles((theme) => ({
+  root: {
+    paddingTop: rem(80),
+    paddingBottom: rem(80),
+  },
+
+  label: {
+    textAlign: "center",
+    fontWeight: 900,
+    fontSize: rem(220),
+    lineHeight: 1,
+    marginBottom: `calc(${theme.spacing.xl} * 1.5)`,
+    color:
+      theme.colorScheme === "dark"
+        ? theme.colors.dark[4]
+        : theme.colors.gray[2],
+
+    [theme.fn.smallerThan("sm")]: {
+      fontSize: rem(120),
+    },
+  },
+
+  title: {
+    fontFamily: `Greycliff CF, ${theme.fontFamily}`,
+    textAlign: "center",
+    fontWeight: 900,
+    fontSize: rem(38),
+
+    [theme.fn.smallerThan("sm")]: {
+      fontSize: rem(32),
+    },
+  },
+
+  description: {
+    maxWidth: rem(500),
+    margin: "auto",
+    marginTop: theme.spacing.xl,
+    marginBottom: `calc(${theme.spacing.xl} * 1.5)`,
+  },
+}));
+
+export function NotFoundTitle() {
+  const { classes } = useStyles();
+
+  return (
+    <Container className={classes.root}>
+      <div className={classes.label}>404</div>
+      <Title className={classes.title}>You have found a secret place.</Title>
+      <Text
+        color="dimmed"
+        size="lg"
+        align="center"
+        className={classes.description}
+      >
+        Unfortunately, this is only a 404 page. You may have mistyped the
+        address, or the page has been moved to another URL.
+      </Text>
+      <Group position="center">
+        <a href="/questions">
+          <Button variant="subtle" size="md">
+            Take me back to home page
+          </Button>
+        </a>
+      </Group>
+    </Container>
+  );
+}

--- a/web-app/src/app/questions/[question]/page.tsx
+++ b/web-app/src/app/questions/[question]/page.tsx
@@ -1,5 +1,33 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { NotFoundTitle } from './404page';
+
 export default function Page({ params }: {
   params: { question: string }
 }) {
-  return <h1>Question {params.question}</h1>;
+  const [questionData, setQuestionData] = useState<any>(null);
+  
+  useEffect(() => {
+    // Define the URL for the API call
+    const apiUrl = `http://localhost:8000/api/questions/${params.question}`;
+
+    // Make the API call using the fetch function
+    fetch(apiUrl)
+      .then(response => response.json())
+      .then(data => setQuestionData(data))
+      .catch(error => console.error('Error fetching data:', error));
+  }, [params.question]);
+
+  if (!questionData) {
+    return <NotFoundTitle />
+  }
+
+  return (
+    <div>
+      <h1>Question {params.question}</h1>
+      {/* Render question data here */}
+      <pre>{JSON.stringify(questionData, null, 2)}</pre>
+    </div>
+  );
 }

--- a/web-app/src/app/questions/page.tsx
+++ b/web-app/src/app/questions/page.tsx
@@ -29,6 +29,7 @@ export default function Page() {
   }, []);
 
   const tableData = apiData.map((item) => ({
+    id: item.id,
     topic: item.topic,
     difficulty: item.difficulty,
     question: item.question,
@@ -85,7 +86,7 @@ export default function Page() {
             {tableData.length > 0 ? (
               <TableSort data={tableData}></TableSort>
             ) : (
-              <Text weight={500} align="center">
+              <Text weight={500} align="center">g
                 Nothing found
               </Text>
             )}


### PR DESCRIPTION
- Each question is routed with it's unique question id. We should look into how we can display the question title in the browser address bar instead of the id.
- Added a custom mantine 404 page if the question id is invalid. 